### PR TITLE
Make compatible for more recent Prettier releases

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "ts-morph": "24.0.0"
   },
   "peerDependencies": {
-    "prettier": "3.4.2"
+    "prettier": "^3.4.2"
   },
   "devDependencies": {
     "@rollup/plugin-commonjs": "28.0.2",


### PR DESCRIPTION
Seems to work fine on 3.5.3 at least!

(Without this there is a fatal install error unless the prettier version is exactly correct.)