### PR TITLE
Switch back to (fixed) babel-ts parser

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,11 +1,10 @@
 const { parsers: babelParsers } = require('prettier/parser-babel');
-const { parsers: typescriptParsers } = require('prettier/parser-typescript');
 const cleanUnusedImports = require('./lib/clean-unused-imports.js');
 
 module.exports = {
   parsers: {
     typescript: {
-      ...typescriptParsers.typescript,
+      ...babelParsers['babel-ts'],
       preprocess: cleanUnusedImports,
     },
     javascript: {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "ts-morph": "24.0.0"
   },
   "peerDependencies": {
-    "prettier": "^3.4.2"
+    "prettier": "^3.6.0"
   },
   "devDependencies": {
     "@rollup/plugin-commonjs": "28.0.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       prettier:
-        specifier: ^3.4.2
-        version: 3.4.2
+        specifier: ^3.6.0
+        version: 3.6.2
       ts-morph:
         specifier: 24.0.0
         version: 24.0.0
@@ -665,8 +665,8 @@ packages:
     resolution: {integrity: sha512-OCVPnIObs4N29kxTjzLfUryOkvZEq+pf8jTF0lg8E7uETuWHA+v7j3c/xJmiqpX450191LlmZfUKkXxkTry7nA==}
     engines: {node: ^10 || ^12 || >=14}
 
-  prettier@3.4.2:
-    resolution: {integrity: sha512-e9MewbtFo+Fevyuxn/4rrcDAaq0IYxPGLvObpQjiZBMAzB9IGmzlnG9RZy3FFas+eBMu2vA0CszMeduow5dIuQ==}
+  prettier@3.6.2:
+    resolution: {integrity: sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==}
     engines: {node: '>=14'}
     hasBin: true
 
@@ -1403,7 +1403,7 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
-  prettier@3.4.2: {}
+  prettier@3.6.2: {}
 
   randombytes@2.1.0:
     dependencies:


### PR DESCRIPTION
Followup to #4

Since a Prettier contributor fixed [the underlying problem in the `babel-ts` parser](https://github.com/prettier/prettier/issues/17489) in PR https://github.com/prettier/prettier/pull/17616 (released in `prettier@3.6.0`), the change from #4 can be reverted, with an upgrade to `prettier@^3.6.0` in `peerDependencies`